### PR TITLE
Fix Missing mozilla-ca Error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -52,6 +52,7 @@ if [ "$(uname -m)" = "armv7l" ]; then
   echo "Exiting."
   exit 1
 fi
+git submodule update --init mozilla-ca
 
 UBUNTU_PRE_2004=false
 if $UBUNTU; then


### PR DESCRIPTION
The line in `install.sh` that clones the `mozilla-ca` submodule was missing, causing the following error:

```
Unable to check permissions for /home/user/stai-blockchain/mozilla-ca/cacert.pem: file /home/user/stai-blockchain/mozilla-ca/cacert.pem does not exist
```